### PR TITLE
Add taints feature and rename skip_stairs to skip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,10 @@
+#########
+Changelog
+#########
+
+0.4.0 (ksindi)
+--------------------
+
+* Rename skip_stairs to skip to incorporate tags at project level
+* Stairs are automatically tagged with their name
+* Add taint to stairs such that only projects with that tag can use them

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Note: For a complete working example see `Buildkite Monorepo Example
       - name: jsproject
         path: jsproject
         emoji: ":javascript:"
-        skip_stairs:
+        skip:
           - deploy-staging
 
 The above buildpipe config file specifies the following:

--- a/buildpipe/schema.json
+++ b/buildpipe/schema.json
@@ -30,13 +30,6 @@
           "type": "object",
           "description": "Environment variables specific to project"
         },
-        "skip_stairs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Stair names to skip"
-        },
         "dependencies": {
           "type": "array",
           "items": {
@@ -50,6 +43,13 @@
             "type": "string"
           },
           "description": "Filter steps by matching tags"
+        },
+        "skip": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Skip steps with certain tags including step name"
         }
       },
       "required": ["name", "path"],
@@ -84,6 +84,13 @@
             "type": "string"
           },
           "description": "Filter steps by matching tags"
+        },
+        "taints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags that a project needs to activate the step"
         }
       },
       "required": ["name", "scope", "buildkite"],

--- a/examples/buildpipe.yml
+++ b/examples/buildpipe.yml
@@ -53,7 +53,7 @@ projects:
   - name: jsproject
     path: jsproject
     emoji: ":javascript:"
-    skip_stairs:
+    skip:
       - deploy-prod
   - name: pyproject
     path: pyproject

--- a/tests/test_buildpipe.py
+++ b/tests/test_buildpipe.py
@@ -224,7 +224,7 @@ def test_compile_steps(mock_get_changed_files, mock_get_git_branch):
 
 @mock.patch('buildpipe.pipeline.get_git_branch')
 @mock.patch('buildpipe.pipeline.get_changed_files')
-def test_skip_stairs(mock_get_changed_files, mock_get_git_branch):
+def test_skip(mock_get_changed_files, mock_get_git_branch):
     config = box_from_yaml("""
     stairs:
       - name: test
@@ -241,7 +241,7 @@ def test_skip_stairs(mock_get_changed_files, mock_get_git_branch):
       - name: myproject
         path: myproject
         emoji: ":python:"
-        skip_stairs:
+        skip:
           - build
     """)
     mock_get_changed_files.return_value = {'origin..HEAD', 'myproject/README.md'}
@@ -283,7 +283,7 @@ def test_tags(mock_get_changed_files, mock_get_git_branch):
         path: project2
       - name: project3
         path: project3
-        skip_stairs:
+        skip:
           - test-integration
     """)
     mock_get_changed_files.return_value = {'project1/README.md', 'project2/README.md', 'project3/README.md'}
@@ -425,26 +425,6 @@ def test_invalidate_config():
             scope: project
             command:
               - make test
-        """)
-        pipeline.compile_steps(config)
-
-
-def test_pipeline_exception():
-    with pytest.raises(pipeline.BuildpipeException):
-        config = box_from_yaml("""
-        deploy: {}
-        stairs:
-          - name: test
-            scope: project
-            buildkite:
-              command:
-                - make test
-        projects:
-          - name: myproject
-            path: myproject
-            emoji: ":python:"
-            skip_stairs:
-              - foo
         """)
         pipeline.compile_steps(config)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = docs,flake8,py36,py37
-skipsdist=True
+skipdist=True
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
* Rename skip_stairs to skip to incorporate tags at project level.
* Stairs are automatically tagged with their name.
* Add taint to stairs such that only projects with that tag can use them.

Example:
```yaml
stairs:
  - name: test
    scope: project
    # projects that have "foo" or "bar" tag can use this step
    tags:
      - foo
      - bar
    # this step can only be run when a project has tag "baz"
    taints:
      - baz
    buildkite:
      command:
        - make test
```