### PR TITLE
Use tag groups and rename skip_stairs and block_steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Note: For a complete working example see `Buildkite Monorepo Example
       - name: jsproject
         path: jsproject
         emoji: ":javascript:"
-        skip_stairs:
+        skip:
           - deploy-staging
 
 The above buildpipe config file specifies the following:

--- a/buildpipe/schema.json
+++ b/buildpipe/schema.json
@@ -4,6 +4,21 @@
   "description": "buildpipe schema",
   "type": "object",
   "definitions": {
+    "StringGroup": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {
+          "type": "array",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          }
+        }]
+      }
+    },
     "Project": {
       "type": "object",
       "properties": {
@@ -19,23 +34,20 @@
           "type": "string",
           "description": "Project emoji"
         },
-        "block_steps": {
+        "block_stairs": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Steps that should have block steps before them"
+          "description": "Stairs that should have a block step before them"
         },
         "env": {
           "type": "object",
           "description": "Environment variables specific to project"
         },
-        "skip_stairs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Stair names to skip"
+        "skip": {
+          "$ref": "#/definitions/StringGroup",
+          "description": "Stair name or tag groups to skip"
         },
         "dependencies": {
           "type": "array",
@@ -45,10 +57,7 @@
           "description": "Paths to include in dependencies"
         },
         "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "$ref": "#/definitions/StringGroup",
           "description": "Filter steps by matching tags"
         }
       },
@@ -79,10 +88,7 @@
           "description": "Buildkite step details"
         },
         "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "$ref": "#/definitions/StringGroup",
           "description": "Filter steps by matching tags"
         }
       },

--- a/examples/buildpipe.yml
+++ b/examples/buildpipe.yml
@@ -53,7 +53,7 @@ projects:
   - name: jsproject
     path: jsproject
     emoji: ":javascript:"
-    skip_stairs:
+    skip:
       - deploy-prod
   - name: pyproject
     path: pyproject


### PR DESCRIPTION
- Allow tags to be either a string or list of strings for more functionality https://github.com/ksindi/buildpipe/issues/31
- Rename skip_stairs to skip to incorporate tag groups
- Rename blocks_steps to blocks_stairs because we're blocking the all the steps