### PR TITLE
[WIP] Separate deploy logic from stair obj

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ Note: For a complete working example see `Buildkite Monorepo Example
     # trigger deploy steps on master during business hours
     deploy:
       branch: master
+      stairs:
+        - deploy-staging
+        - deploy-prod
       timezone: US/Eastern
       allowed_hours_regex: '9|1[0-7]'
       allowed_weekdays_regex: '[1-5]'
@@ -78,7 +81,6 @@ Note: For a complete working example see `Buildkite Monorepo Example
       - name: deploy-staging
         scope: project
         emoji: ":shipit:"
-        deploy: true
         buildkite:
           branches: master
           command:
@@ -87,7 +89,6 @@ Note: For a complete working example see `Buildkite Monorepo Example
       - name: deploy-prod
         scope: project
         emoji: ":shipit:"
-        deploy: true
         buildkite:
           branches: master
           command:

--- a/buildpipe/schema.json
+++ b/buildpipe/schema.json
@@ -70,10 +70,6 @@
           "type": "string",
           "description": "Emoji to use in labels"
         },
-        "deploy": {
-          "type": "boolean",
-          "description": "Whether to apply deployment logic such as business hour rules"
-        },
         "buildkite": {
           "type": "object",
           "description": "Buildkite step details"
@@ -104,6 +100,10 @@
         "branch": {
           "type": "string",
           "description": "Branch eligible to deploy [Default: master]"
+        },
+        "stairs": {
+          "type": "array",
+          "description": "Stair names considered deployable"
         },
         "timezone": {
           "type": "string",

--- a/examples/buildpipe.yml
+++ b/examples/buildpipe.yml
@@ -1,5 +1,8 @@
 deploy:
   branch: master
+  stairs:
+    - deploy-staging
+    - deploy-prod
   timezone: US/Eastern
   allowed_hours_regex: '9|1[0-7]'
   allowed_weekdays_regex: '[1-5]'
@@ -34,7 +37,6 @@ stairs:
   - name: deploy-staging
     scope: project
     emoji: ":shipit:"
-    deploy: true
     buildkite:
       branches: "master"
       command:
@@ -43,7 +45,6 @@ stairs:
   - name: deploy-prod
     scope: project
     emoji: ":shipit:"
-    deploy: true
     buildkite:
       branches: "master"
       command:

--- a/tests/test_buildpipe.py
+++ b/tests/test_buildpipe.py
@@ -133,7 +133,6 @@ def test_compile_steps(mock_get_changed_files, mock_get_git_branch):
       - name: deploy-staging
         scope: project
         emoji: ":shipit:"
-        deploy: true
         buildkite:
           branches: master
           command:
@@ -142,7 +141,6 @@ def test_compile_steps(mock_get_changed_files, mock_get_git_branch):
       - name: deploy-prod
         scope: project
         emoji: ":shipit:"
-        deploy: true
         buildkite:
           branches: master
           env:
@@ -380,6 +378,8 @@ def test_no_deploy(mock_get_changed_files, mock_get_git_branch):
     config = box_from_yaml("""
     deploy:
       branch: master
+      stairs:
+        - deploy
       timezone: UTC
       allowed_hours_regex: '9|1[0-7]'
     stairs:
@@ -390,7 +390,6 @@ def test_no_deploy(mock_get_changed_files, mock_get_git_branch):
             - make test
       - name: deploy
         scope: project
-        deploy: true
         buildkite:
           command:
             - make deploy
@@ -463,6 +462,8 @@ def test_block_step(mock_get_changed_files, mock_get_git_branch):
     config = box_from_yaml("""
     deploy:
       branch: master
+      stairs:
+        - deploy
     block:
       block: "Release!"
     stairs:
@@ -473,7 +474,6 @@ def test_block_step(mock_get_changed_files, mock_get_git_branch):
             - make test
       - name: deploy
         scope: project
-        deploy: true
         buildkite:
           command:
             - make deploy


### PR DESCRIPTION
Related to https://github.com/ksindi/buildpipe/issues/29

Blocker: How does one generalize concurrency groups? Is it possible to do:
```
stairs:
    - name: deploy-prod
        scope: project
        emoji: ":shipit:"
        buildkite:
          branches: master
          concurrency-group: $$BUILDPIPE_STAIR_NAME-$$BUILDPIPE_PROJECT_NAME
          command:
            - cd $$BUILDPIPE_PROJECT_PATH
            - make deploy-prod
```