### PR TITLE
Add continue on failure functionality

### DIFF
--- a/buildpipe/schema.json
+++ b/buildpipe/schema.json
@@ -103,6 +103,10 @@
           "type": "boolean",
           "description": "Whether to apply deployment logic such as business hour rules"
         },
+        "continue_on_failure": {
+          "type": "boolean",
+          "description": "Whether to continue if the stair fails"
+        },
         "buildkite": {
           "type": "object",
           "description": "Buildkite step details"


### PR DESCRIPTION
This should add the ability for stair to say that the build should continue on failure:
https://buildkite.com/docs/pipelines/wait-step#continuing-on-failure