### PR TITLE
Use ruamel.yaml instead of pyaml

### DIFF
--- a/buildpipe/pipeline.py
+++ b/buildpipe/pipeline.py
@@ -12,9 +12,9 @@ import collections
 from typing import Dict, List, Tuple, Set, Generator, Callable, NoReturn, Union
 
 import box
-import yaml
 import pytz
 import jsonschema
+from ruamel import yaml
 
 TAGS = List[Union[str, Tuple[str]]]
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     license='MIT',
     install_requires=[
         'jsonschema>=2.6.0',
-        'pyaml>=17.10.0',
-        'python-box>=3.1.1',
+        'ruamel.yaml>=0.16.5',
+        'python-box>=4.0.1',
         'pytz>=2017.2',
     ],
     setup_requires=[

--- a/tests/test_buildpipe.py
+++ b/tests/test_buildpipe.py
@@ -6,10 +6,10 @@ import datetime
 import textwrap
 from unittest import mock
 
-import yaml
 import pytest
 import freezegun
 from box import Box
+from ruamel import yaml
 
 from buildpipe import pipeline
 from buildpipe.__main__ import create_parser


### PR DESCRIPTION
pyaml won't work when using SafeDumper

```
import box
import yaml

b = box.Box({"a": 1})
b.to_yaml()  # 'a: 1\n'

b.to_yaml(Dumper=yaml.dumper.SafeDumper)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/box/box.py", line 662, in to_yaml
    encoding=encoding, errors=errors, **yaml_kwargs)
  File "/usr/local/lib/python3.7/site-packages/box/converters.py", line 70, in _to_yaml
    return yaml.dump(obj, default_flow_style=default_flow_style, **yaml_kwargs)
  File "/usr/local/lib/python3.7/site-packages/ruamel/yaml/main.py", line 1248, in dump
    block_seq_indent=block_seq_indent,
  File "/usr/local/lib/python3.7/site-packages/ruamel/yaml/main.py", line 1184, in dump_all
    prefix_colon=prefix_colon,
TypeError: __init__() got an unexpected keyword argument 'block_seq_indent'
```