### PR TITLE
Change pipeline steps if buildkite trigger step is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ ENV/
 
 # pytest
 .pytest_cache/
+
+# MacOS
+.DS_Store
+
+# Jetbrains
+.idea

--- a/buildpipe/pipeline.py
+++ b/buildpipe/pipeline.py
@@ -236,6 +236,16 @@ def iter_stair_projects(stair: box.Box, projects: Set[box.Box]) -> Generator[box
             yield project
 
 
+def check_for_trigger_steps(build_steps):
+    updated_steps = []
+    for step in build_steps:
+        if 'trigger' in step:
+            step['build'] = {}
+            step['build']['env'] = step['env']
+            del step['env']
+    return updated_steps
+
+
 def compile_steps(config: box.Box) -> box.Box:
     validate_config(config)
     branch = get_git_branch()
@@ -251,6 +261,7 @@ def compile_steps(config: box.Box) -> box.Box:
             steps += generate_wait_step(previous_stair)
             steps += generate_block_step(config.block.to_dict(), stair, stair_projects)
             steps += scope_fn[stair.scope](stair, stair_projects)
+        steps = check_for_trigger_steps(steps)
         previous_stair = stair
 
     return box.Box({'steps': steps})


### PR DESCRIPTION
Buildkite has special [`trigger` steps to trigger other pipelines](https://buildkite.com/docs/pipelines/trigger-step).
Those steps don't allow `env` attributes next to them. They need to be under a `build` attribute so that they are applied for the newly triggered build.

This PR solves issue #39.