### PR TITLE
Support paths that end with trailing slashes

### DIFF
--- a/buildpipe/pipeline.py
+++ b/buildpipe/pipeline.py
@@ -163,11 +163,10 @@ def generate_stair_steps(stair: box.Box, projects: Set[box.Box]) -> List[Dict]:
 
 def check_project_affected(changed_files: Set[str], project: box.Box) -> bool:
     for path in [project.path] + list(project.get('dependencies', [])):
+        if path == '.':
+            return True
         for changed_file in changed_files:
-            project_dirs = path.split('/')
-            changed_dirs = changed_file.split('/')
-
-            if path == '.' or changed_dirs[:len(project_dirs)] == project_dirs:
+            if changed_file.startswith(path):
                 return True
     return False
 

--- a/buildpipe/pipeline.py
+++ b/buildpipe/pipeline.py
@@ -165,8 +165,10 @@ def check_project_affected(changed_files: Set[str], project: box.Box) -> bool:
     for path in [project.path] + list(project.get('dependencies', [])):
         if path == '.':
             return True
+        project_dirs = os.path.normpath(path).split('/')
         for changed_file in changed_files:
-            if changed_file.startswith(path):
+            changed_dirs = changed_file.split('/')
+            if changed_dirs[:len(project_dirs)] == project_dirs:
                 return True
     return False
 

--- a/tests/test_buildpipe.py
+++ b/tests/test_buildpipe.py
@@ -93,12 +93,12 @@ def test_get_affected_projects(mock_get_changed_files, changed_files, expected):
       - name: project3
         path: project3
       - name: project4
-        path: project4
+        path: project4/
         dependencies:
           - project2
           - project3
       - name: project5
-        path: nested/path
+        path: nested/path/
     """))
     mock_get_changed_files.return_value = changed_files
     projects = pipeline.get_affected_projects('branch', config)


### PR DESCRIPTION
This didn't appear to be supported by buildpipe and has puzzled me for a while. Since directories are usually indicated with a trailing slash, buildpipe should probably support this as well.